### PR TITLE
Add PII detection and redaction (d023)

### DIFF
--- a/src/prompt_shield/compliance/owasp_mapping.py
+++ b/src/prompt_shield/compliance/owasp_mapping.py
@@ -123,6 +123,7 @@ DETECTOR_OWASP_MAP: dict[str, list[str]] = {
     "d020_nested_instruction": ["LLM01"],
     "d021_vault_similarity": ["LLM01"],
     "d022_semantic_classifier": ["LLM01"],
+    "d023_pii_detection": ["LLM02"],
 }
 
 # All valid OWASP category IDs for validation

--- a/src/prompt_shield/config/default.yaml
+++ b/src/prompt_shield/config/default.yaml
@@ -119,6 +119,17 @@ prompt_shield:
       threshold: 0.7
       model_name: "protectai/deberta-v3-base-prompt-injection-v2"
       device: "cpu"
+    d023_pii_detection:
+      enabled: true
+      severity: high
+      entities:
+        email: true
+        phone: true
+        ssn: true
+        credit_card: true
+        api_key: true
+        ip_address: true
+      custom_patterns: []
 
   allowlist:
     patterns: []

--- a/src/prompt_shield/detectors/d023_pii_detection.py
+++ b/src/prompt_shield/detectors/d023_pii_detection.py
@@ -1,0 +1,119 @@
+"""Detector for personally identifiable information (PII) in prompts."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import regex
+
+from prompt_shield.detectors.base import BaseDetector
+from prompt_shield.models import DetectionResult, MatchDetail, Severity
+from prompt_shield.pii.entity_types import DEFAULT_PII_PATTERNS, EntityType
+
+
+class PIIDetectionDetector(BaseDetector):
+    """Detects personally identifiable information in prompt text.
+
+    Scans for emails, phone numbers, SSNs, credit card numbers,
+    API keys/secrets, and IP addresses. Each entity type can be
+    independently enabled/disabled via config.
+    """
+
+    detector_id: str = "d023_pii_detection"
+    name: str = "PII Detection"
+    description: str = (
+        "Detects personally identifiable information such as emails, "
+        "phone numbers, SSNs, credit cards, API keys, and IP addresses"
+    )
+    severity: Severity = Severity.HIGH
+    tags: ClassVar[list[str]] = ["data_protection"]
+    version: str = "1.0.0"
+    author: str = "prompt-shield"
+
+    _base_confidence: float = 0.90
+
+    def __init__(self) -> None:
+        self._enabled_entities: set[str] = {e.value for e in EntityType}
+        self._compiled_patterns: list[tuple[EntityType, regex.Pattern[str], str]] = []
+        self._custom_patterns: list[tuple[str, str]] = []
+        self._compile_patterns()
+
+    def _compile_patterns(self) -> None:
+        """Pre-compile regex patterns for enabled entity types."""
+        self._compiled_patterns = []
+        for entity_type, pattern_str, description in DEFAULT_PII_PATTERNS:
+            if entity_type.value in self._enabled_entities:
+                compiled = regex.compile(pattern_str, regex.IGNORECASE)
+                self._compiled_patterns.append((entity_type, compiled, description))
+
+    def setup(self, config: dict[str, object]) -> None:
+        """Configure enabled entity types and custom patterns from YAML config."""
+        entities_config = config.get("entities", {})
+        if isinstance(entities_config, dict):
+            for entity_name, enabled in entities_config.items():
+                if enabled is False and entity_name in self._enabled_entities:
+                    self._enabled_entities.discard(entity_name)
+                elif enabled is True:
+                    self._enabled_entities.add(entity_name)
+
+        custom = config.get("custom_patterns", [])
+        if isinstance(custom, list):
+            self._custom_patterns = [(p.get("pattern", ""), p.get("description", "Custom PII pattern")) for p in custom if isinstance(p, dict) and p.get("pattern")]
+
+        self._compile_patterns()
+
+    def detect(
+        self, input_text: str, context: dict[str, object] | None = None
+    ) -> DetectionResult:
+        matches: list[MatchDetail] = []
+        entity_counts: dict[str, int] = {}
+
+        for entity_type, compiled, description in self._compiled_patterns:
+            for m in compiled.finditer(input_text):
+                matches.append(
+                    MatchDetail(
+                        pattern=compiled.pattern,
+                        matched_text=m.group(),
+                        position=(m.start(), m.end()),
+                        description=f"[{entity_type.value}] {description}",
+                    )
+                )
+                entity_counts[entity_type.value] = (
+                    entity_counts.get(entity_type.value, 0) + 1
+                )
+
+        # Custom patterns (no entity type prefix)
+        for pattern_str, description in self._custom_patterns:
+            try:
+                compiled_custom = regex.compile(pattern_str, regex.IGNORECASE)
+                for m in compiled_custom.finditer(input_text):
+                    matches.append(
+                        MatchDetail(
+                            pattern=pattern_str,
+                            matched_text=m.group(),
+                            position=(m.start(), m.end()),
+                            description=description,
+                        )
+                    )
+            except regex.error:
+                continue
+
+        if not matches:
+            return DetectionResult(
+                detector_id=self.detector_id,
+                detected=False,
+                confidence=0.0,
+                severity=self.severity,
+                explanation="No PII detected",
+            )
+
+        confidence = min(1.0, self._base_confidence + 0.02 * (len(matches) - 1))
+        return DetectionResult(
+            detector_id=self.detector_id,
+            detected=True,
+            confidence=confidence,
+            severity=self.severity,
+            matches=matches,
+            explanation=f"Detected {len(matches)} PII instance(s) across {len(entity_counts)} entity type(s)",
+            metadata={"entity_counts": entity_counts},
+        )

--- a/src/prompt_shield/models.py
+++ b/src/prompt_shield/models.py
@@ -89,6 +89,16 @@ class ThreatFeed(BaseModel):
     threats: list[ThreatEntry]
 
 
+class RedactionResult(BaseModel):
+    """Result from PII redaction."""
+
+    original_text: str
+    redacted_text: str
+    redaction_count: int
+    entity_counts: dict[str, int] = {}
+    redacted_entities: list[dict[str, str]] = []
+
+
 class GateResult(BaseModel):
     """Result from any AgentGuard gate scan."""
 

--- a/src/prompt_shield/pii/__init__.py
+++ b/src/prompt_shield/pii/__init__.py
@@ -1,0 +1,15 @@
+"""PII detection and redaction utilities."""
+
+from prompt_shield.pii.entity_types import (
+    DEFAULT_PII_PATTERNS,
+    DEFAULT_REPLACEMENTS,
+    EntityType,
+)
+from prompt_shield.pii.redactor import PIIRedactor
+
+__all__ = [
+    "DEFAULT_PII_PATTERNS",
+    "DEFAULT_REPLACEMENTS",
+    "EntityType",
+    "PIIRedactor",
+]

--- a/src/prompt_shield/pii/entity_types.py
+++ b/src/prompt_shield/pii/entity_types.py
@@ -1,0 +1,112 @@
+"""PII entity type definitions and default detection patterns."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EntityType(str, Enum):
+    """Supported PII entity types."""
+
+    EMAIL = "email"
+    PHONE = "phone"
+    SSN = "ssn"
+    CREDIT_CARD = "credit_card"
+    API_KEY = "api_key"
+    IP_ADDRESS = "ip_address"
+
+
+# Each entry: (entity_type, regex_pattern, description)
+DEFAULT_PII_PATTERNS: list[tuple[EntityType, str, str]] = [
+    # --- Email ---
+    (
+        EntityType.EMAIL,
+        r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+        "Email address",
+    ),
+    # --- Phone ---
+    (
+        EntityType.PHONE,
+        r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b",
+        "US phone number",
+    ),
+    (
+        EntityType.PHONE,
+        r"\+\d{1,3}[-.\s]?\d{4,14}",
+        "International phone number",
+    ),
+    # --- SSN ---
+    (
+        EntityType.SSN,
+        r"\b\d{3}-\d{2}-\d{4}\b",
+        "Social Security Number",
+    ),
+    # --- Credit Card ---
+    (
+        EntityType.CREDIT_CARD,
+        r"\b4\d{3}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b",
+        "Visa card number",
+    ),
+    (
+        EntityType.CREDIT_CARD,
+        r"\b5[1-5]\d{2}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b",
+        "Mastercard number",
+    ),
+    (
+        EntityType.CREDIT_CARD,
+        r"\b3[47]\d{2}[-\s]?\d{6}[-\s]?\d{5}\b",
+        "American Express card number",
+    ),
+    (
+        EntityType.CREDIT_CARD,
+        r"\b6(?:011|5\d{2})[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b",
+        "Discover card number",
+    ),
+    # --- API Key ---
+    (
+        EntityType.API_KEY,
+        r"\bAKIA[0-9A-Z]{16}\b",
+        "AWS access key ID",
+    ),
+    (
+        EntityType.API_KEY,
+        r"\bghp_[a-zA-Z0-9]{36}\b",
+        "GitHub personal access token",
+    ),
+    (
+        EntityType.API_KEY,
+        r"\bgho_[a-zA-Z0-9]{36}\b",
+        "GitHub OAuth token",
+    ),
+    (
+        EntityType.API_KEY,
+        r"\bghu_[a-zA-Z0-9]{36}\b",
+        "GitHub user-to-server token",
+    ),
+    (
+        EntityType.API_KEY,
+        r"\bxox[bpras]-[a-zA-Z0-9\-]+",
+        "Slack token",
+    ),
+    (
+        EntityType.API_KEY,
+        r"(?:api[_-]?key|apikey)\s*[=:]\s*['\"]?[a-zA-Z0-9_\-]{20,}['\"]?",
+        "Generic API key assignment",
+    ),
+    # --- IP Address ---
+    (
+        EntityType.IP_ADDRESS,
+        r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b",
+        "IPv4 address",
+    ),
+]
+
+# Default replacement strings per entity type
+DEFAULT_REPLACEMENTS: dict[EntityType, str] = {
+    EntityType.EMAIL: "[EMAIL_REDACTED]",
+    EntityType.PHONE: "[PHONE_REDACTED]",
+    EntityType.SSN: "[SSN_REDACTED]",
+    EntityType.CREDIT_CARD: "[CREDIT_CARD_REDACTED]",
+    EntityType.API_KEY: "[API_KEY_REDACTED]",
+    EntityType.IP_ADDRESS: "[IP_ADDRESS_REDACTED]",
+}

--- a/src/prompt_shield/pii/redactor.py
+++ b/src/prompt_shield/pii/redactor.py
@@ -1,0 +1,148 @@
+"""Standalone PII redactor with entity-type-aware placeholders."""
+
+from __future__ import annotations
+
+import regex
+
+from prompt_shield.models import RedactionResult
+from prompt_shield.pii.entity_types import (
+    DEFAULT_PII_PATTERNS,
+    DEFAULT_REPLACEMENTS,
+    EntityType,
+)
+
+
+class PIIRedactor:
+    """Detects and redacts PII from text with entity-type-aware placeholders.
+
+    Can be used standalone (without AgentGuard) or integrated into the
+    sanitization pipeline.
+    """
+
+    def __init__(
+        self,
+        replacements: dict[EntityType, str] | None = None,
+        enabled_entities: set[EntityType] | None = None,
+    ) -> None:
+        self._replacements = replacements or dict(DEFAULT_REPLACEMENTS)
+        self._enabled_entities = enabled_entities or set(EntityType)
+        self._compiled_patterns: list[tuple[EntityType, regex.Pattern[str], str]] = []
+        self._compile_patterns()
+
+    def _compile_patterns(self) -> None:
+        self._compiled_patterns = []
+        for entity_type, pattern_str, description in DEFAULT_PII_PATTERNS:
+            if entity_type in self._enabled_entities:
+                compiled = regex.compile(pattern_str, regex.IGNORECASE)
+                self._compiled_patterns.append((entity_type, compiled, description))
+
+    def redact(self, text: str) -> RedactionResult:
+        """Detect and redact all PII from the given text.
+
+        Returns a RedactionResult with the redacted text, counts, and entity details.
+        """
+        # Collect all matches: (start, end, entity_type, matched_text)
+        raw_matches: list[tuple[int, int, EntityType, str]] = []
+
+        for entity_type, compiled, _description in self._compiled_patterns:
+            for m in compiled.finditer(text):
+                raw_matches.append((m.start(), m.end(), entity_type, m.group()))
+
+        if not raw_matches:
+            return RedactionResult(
+                original_text=text,
+                redacted_text=text,
+                redaction_count=0,
+                entity_counts={},
+                redacted_entities=[],
+            )
+
+        # Deduplicate overlapping matches: keep the longest match at each position
+        raw_matches.sort(key=lambda x: (x[0], -(x[1] - x[0])))
+        deduped: list[tuple[int, int, EntityType, str]] = []
+        for match in raw_matches:
+            if deduped and match[0] < deduped[-1][1]:
+                # Overlapping — skip shorter match
+                continue
+            deduped.append(match)
+
+        # Replace in reverse order to preserve positions
+        entity_counts: dict[str, int] = {}
+        redacted_entities: list[dict[str, str]] = []
+        result = text
+
+        for start, end, entity_type, matched_text in reversed(deduped):
+            replacement = self._replacements.get(
+                entity_type, f"[{entity_type.value.upper()}_REDACTED]"
+            )
+            result = result[:start] + replacement + result[end:]
+            entity_counts[entity_type.value] = (
+                entity_counts.get(entity_type.value, 0) + 1
+            )
+            redacted_entities.append(
+                {"entity_type": entity_type.value, "original": matched_text}
+            )
+
+        redacted_entities.reverse()
+
+        return RedactionResult(
+            original_text=text,
+            redacted_text=result,
+            redaction_count=len(deduped),
+            entity_counts=entity_counts,
+            redacted_entities=redacted_entities,
+        )
+
+    def redact_with_detections(self, text: str, matches: list[dict]) -> str:
+        """Redact text using pre-existing detection matches from d023.
+
+        Each match dict should have 'description' with '[entity_type] ...' prefix
+        and 'position' as (start, end) tuple.
+        """
+        # Parse entity types from descriptions and collect positions
+        replacements: list[tuple[int, int, str]] = []
+
+        for match in matches:
+            position = match.get("position")
+            if not position:
+                continue
+
+            start, end = position
+            description = match.get("description", "")
+
+            # Parse [entity_type] prefix
+            replacement = self._replacements.get(
+                EntityType.EMAIL, "[PII_REDACTED]"
+            )  # fallback
+            if description.startswith("["):
+                closing = description.find("]")
+                if closing > 0:
+                    entity_str = description[1:closing]
+                    try:
+                        entity_type = EntityType(entity_str)
+                        replacement = self._replacements.get(
+                            entity_type, f"[{entity_str.upper()}_REDACTED]"
+                        )
+                    except ValueError:
+                        replacement = f"[{entity_str.upper()}_REDACTED]"
+
+            replacements.append((start, end, replacement))
+
+        if not replacements:
+            return text
+
+        # Sort by position descending for safe replacement
+        replacements.sort(key=lambda x: x[0], reverse=True)
+
+        # Deduplicate overlapping
+        deduped: list[tuple[int, int, str]] = []
+        for r in replacements:
+            if deduped and r[1] > deduped[-1][0]:
+                continue
+            deduped.append(r)
+
+        result = text
+        for start, end, replacement in deduped:
+            result = result[:start] + replacement + result[end:]
+
+        return result

--- a/tests/compliance/test_owasp_mapping.py
+++ b/tests/compliance/test_owasp_mapping.py
@@ -12,7 +12,7 @@ from prompt_shield.compliance.owasp_mapping import (
 )
 
 
-# All 22 built-in detector IDs
+# All 23 built-in detector IDs
 ALL_DETECTOR_IDS = [
     "d001_system_prompt_extraction",
     "d002_role_hijack",
@@ -36,6 +36,7 @@ ALL_DETECTOR_IDS = [
     "d020_nested_instruction",
     "d021_vault_similarity",
     "d022_semantic_classifier",
+    "d023_pii_detection",
 ]
 
 # Fake metadata matching the IDs
@@ -75,14 +76,14 @@ class TestOwaspIdValidity:
 
 
 class TestComplianceReportFull:
-    """Report generated with all 22 detectors."""
+    """Report generated with all 23 detectors."""
 
     @pytest.fixture
     def full_report(self):
         return generate_compliance_report(ALL_DETECTOR_IDS, ALL_DETECTOR_METADATA)
 
     def test_total_detectors(self, full_report) -> None:
-        assert full_report.total_detectors == 22
+        assert full_report.total_detectors == 23
 
     def test_owasp_version(self, full_report) -> None:
         assert full_report.owasp_version == "2025"

--- a/tests/detectors/test_d023_pii_detection.py
+++ b/tests/detectors/test_d023_pii_detection.py
@@ -1,0 +1,159 @@
+"""Tests for d023 PII detection detector."""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_shield.detectors.d023_pii_detection import PIIDetectionDetector
+
+
+@pytest.fixture
+def detector():
+    return PIIDetectionDetector()
+
+
+class TestPIIDetection:
+    """Tests for each entity type and edge cases."""
+
+    # --- Email ---
+
+    def test_email_detected(self, detector):
+        result = detector.detect("Contact me at user@example.com for details")
+        assert result.detected is True
+        assert any("[email]" in m.description for m in result.matches)
+
+    def test_email_multiple(self, detector):
+        result = detector.detect("Emails: a@b.com and c@d.org")
+        assert result.detected is True
+        email_matches = [m for m in result.matches if "[email]" in m.description]
+        assert len(email_matches) == 2
+
+    # --- Phone ---
+
+    def test_phone_us_format(self, detector):
+        result = detector.detect("Call me at 555-123-4567")
+        assert result.detected is True
+        assert any("[phone]" in m.description for m in result.matches)
+
+    def test_phone_parentheses(self, detector):
+        result = detector.detect("Phone: (555) 123-4567")
+        assert result.detected is True
+
+    def test_phone_international(self, detector):
+        result = detector.detect("My number is +44 7911123456")
+        assert result.detected is True
+
+    # --- SSN ---
+
+    def test_ssn_detected(self, detector):
+        result = detector.detect("My SSN is 123-45-6789")
+        assert result.detected is True
+        assert any("[ssn]" in m.description for m in result.matches)
+
+    def test_ssn_not_partial(self, detector):
+        result = detector.detect("Order number 12345-6789")
+        # Should NOT match as SSN (wrong format)
+        ssn_matches = [m for m in result.matches if "[ssn]" in m.description]
+        assert len(ssn_matches) == 0
+
+    # --- Credit Card ---
+
+    def test_visa_detected(self, detector):
+        result = detector.detect("Card: 4111-1111-1111-1111")
+        assert result.detected is True
+        assert any("[credit_card]" in m.description for m in result.matches)
+
+    def test_mastercard_detected(self, detector):
+        result = detector.detect("Card: 5111 2222 3333 4444")
+        assert result.detected is True
+
+    def test_amex_detected(self, detector):
+        result = detector.detect("Amex: 3412 345678 12345")
+        assert result.detected is True
+
+    # --- API Key ---
+
+    def test_aws_key_detected(self, detector):
+        result = detector.detect("Key: AKIAIOSFODNN7EXAMPLE")
+        assert result.detected is True
+        assert any("[api_key]" in m.description for m in result.matches)
+
+    def test_github_token_detected(self, detector):
+        result = detector.detect("Token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
+        assert result.detected is True
+
+    def test_slack_token_detected(self, detector):
+        result = detector.detect("Slack: xoxb-123456789-abcdef")
+        assert result.detected is True
+
+    def test_generic_api_key_detected(self, detector):
+        result = detector.detect("api_key=sk_live_abcdefghijklmnopqrst")
+        assert result.detected is True
+
+    # --- IP Address ---
+
+    def test_ip_address_detected(self, detector):
+        result = detector.detect("Server at 192.168.1.100")
+        assert result.detected is True
+        assert any("[ip_address]" in m.description for m in result.matches)
+
+    def test_ip_invalid_range(self, detector):
+        result = detector.detect("Value is 999.999.999.999")
+        ip_matches = [m for m in result.matches if "[ip_address]" in m.description]
+        assert len(ip_matches) == 0
+
+    # --- Benign ---
+
+    def test_benign_text(self, detector):
+        result = detector.detect("Hello, how are you today?")
+        assert result.detected is False
+        assert result.confidence == 0.0
+
+    def test_benign_question(self, detector):
+        result = detector.detect("What is the weather like in New York?")
+        assert result.detected is False
+
+    # --- Multiple entities ---
+
+    def test_multiple_entity_types(self, detector):
+        text = "Email: user@example.com, SSN: 123-45-6789, Phone: 555-123-4567"
+        result = detector.detect(text)
+        assert result.detected is True
+        assert result.confidence >= 0.90
+        entity_counts = result.metadata.get("entity_counts", {})
+        assert "email" in entity_counts
+        assert "ssn" in entity_counts
+        assert "phone" in entity_counts
+
+    # --- Confidence ---
+
+    def test_confidence_base(self, detector):
+        result = detector.detect("Contact: user@example.com")
+        assert result.detected is True
+        assert result.confidence == 0.90
+
+    def test_confidence_increases(self, detector):
+        result = detector.detect("user@a.com and user@b.com and user@c.com")
+        assert result.confidence > 0.90
+
+    # --- Config ---
+
+    def test_config_disable_entity(self, detector):
+        detector.setup({"entities": {"email": False}})
+        result = detector.detect("Contact: user@example.com")
+        email_matches = [m for m in result.matches if "[email]" in m.description]
+        assert len(email_matches) == 0
+
+    # --- Metadata ---
+
+    def test_metadata_entity_counts(self, detector):
+        result = detector.detect("user@example.com and 123-45-6789")
+        assert result.detected is True
+        assert "entity_counts" in result.metadata
+
+    # --- Result fields ---
+
+    def test_result_fields(self, detector):
+        result = detector.detect("Email: test@example.com")
+        assert result.detector_id == "d023_pii_detection"
+        assert result.severity.value == "high"

--- a/tests/pii/__init__.py
+++ b/tests/pii/__init__.py
@@ -1,0 +1,1 @@
+"""PII tests package."""

--- a/tests/pii/test_redactor.py
+++ b/tests/pii/test_redactor.py
@@ -1,0 +1,117 @@
+"""Tests for the PII redactor."""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_shield.pii.entity_types import EntityType
+from prompt_shield.pii.redactor import PIIRedactor
+
+
+@pytest.fixture
+def redactor():
+    return PIIRedactor()
+
+
+class TestPIIRedactor:
+    """Tests for per-entity redaction, custom replacements, and edge cases."""
+
+    # --- Per-entity redaction ---
+
+    def test_redact_email(self, redactor):
+        result = redactor.redact("Contact user@example.com for help")
+        assert "[EMAIL_REDACTED]" in result.redacted_text
+        assert "user@example.com" not in result.redacted_text
+        assert result.redaction_count == 1
+        assert result.entity_counts.get("email") == 1
+
+    def test_redact_phone(self, redactor):
+        result = redactor.redact("Call 555-123-4567 now")
+        assert "[PHONE_REDACTED]" in result.redacted_text
+        assert "555-123-4567" not in result.redacted_text
+
+    def test_redact_ssn(self, redactor):
+        result = redactor.redact("SSN: 123-45-6789")
+        assert "[SSN_REDACTED]" in result.redacted_text
+        assert "123-45-6789" not in result.redacted_text
+
+    def test_redact_credit_card(self, redactor):
+        result = redactor.redact("Visa: 4111-1111-1111-1111")
+        assert "[CREDIT_CARD_REDACTED]" in result.redacted_text
+        assert "4111-1111-1111-1111" not in result.redacted_text
+
+    def test_redact_api_key(self, redactor):
+        result = redactor.redact("Key: AKIAIOSFODNN7EXAMPLE")
+        assert "[API_KEY_REDACTED]" in result.redacted_text
+
+    def test_redact_ip_address(self, redactor):
+        result = redactor.redact("Server: 192.168.1.100")
+        assert "[IP_ADDRESS_REDACTED]" in result.redacted_text
+
+    # --- Multiple entities ---
+
+    def test_redact_multiple_types(self, redactor):
+        text = "Email: user@test.com, SSN: 123-45-6789"
+        result = redactor.redact(text)
+        assert "[EMAIL_REDACTED]" in result.redacted_text
+        assert "[SSN_REDACTED]" in result.redacted_text
+        assert result.redaction_count == 2
+        assert result.entity_counts.get("email") == 1
+        assert result.entity_counts.get("ssn") == 1
+
+    def test_redact_multiple_same_type(self, redactor):
+        text = "a@b.com and c@d.com"
+        result = redactor.redact(text)
+        assert result.redacted_text.count("[EMAIL_REDACTED]") == 2
+        assert result.entity_counts.get("email") == 2
+
+    # --- No PII ---
+
+    def test_no_pii_passthrough(self, redactor):
+        text = "Hello, how are you today?"
+        result = redactor.redact(text)
+        assert result.redacted_text == text
+        assert result.redaction_count == 0
+        assert result.entity_counts == {}
+
+    # --- Custom replacements ---
+
+    def test_custom_replacements(self):
+        custom = {EntityType.EMAIL: "***EMAIL***"}
+        redactor = PIIRedactor(replacements=custom)
+        result = redactor.redact("Contact user@test.com")
+        assert "***EMAIL***" in result.redacted_text
+
+    # --- Entity details ---
+
+    def test_redacted_entities_list(self, redactor):
+        result = redactor.redact("user@example.com")
+        assert len(result.redacted_entities) == 1
+        assert result.redacted_entities[0]["entity_type"] == "email"
+        assert result.redacted_entities[0]["original"] == "user@example.com"
+
+    # --- Original preserved ---
+
+    def test_original_text_preserved(self, redactor):
+        text = "user@example.com"
+        result = redactor.redact(text)
+        assert result.original_text == text
+
+    # --- redact_with_detections ---
+
+    def test_redact_with_detections(self, redactor):
+        text = "Email: user@example.com here"
+        matches = [
+            {
+                "description": "[email] Email address",
+                "position": (7, 23),
+            }
+        ]
+        result = redactor.redact_with_detections(text, matches)
+        assert "[EMAIL_REDACTED]" in result
+        assert "user@example.com" not in result
+
+    def test_redact_with_detections_no_matches(self, redactor):
+        text = "No PII here"
+        result = redactor.redact_with_detections(text, [])
+        assert result == text


### PR DESCRIPTION
## Summary
- Add new `d023_pii_detection` detector scanning for 6 PII entity types (email, phone, SSN, credit card, API key, IP address) with 16 regex patterns
- Add standalone `PIIRedactor` with entity-type-aware placeholders (`[EMAIL_REDACTED]`, `[SSN_REDACTED]`, etc.) and overlap deduplication
- Add CLI `pii scan` and `pii redact` subcommands with `--json-output` support
- Wire PII redactor into AgentGuard `_sanitize_text()` for entity-aware redaction
- Map d023 to OWASP LLM02 (Sensitive Information Disclosure)

## Test plan
- [x] 24 detector tests covering all 6 entity types, benign inputs, config-based disable, metadata
- [x] 14 redactor tests covering per-entity redaction, custom replacements, overlap handling, no-PII passthrough
- [x] 8 CLI tests for pii scan/redact (text + JSON output, clean + PII inputs)
- [x] Full suite: 482 tests passed, 0 failures