### PR TITLE
Wire in Zenodo DOI 10.5281/zenodo.19644135 for v0.4.0 research paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you use prompt-shield in research, please cite the research paper (preferred) or this software repository."
+title: "prompt-shield"
+abstract: "Self-learning prompt injection detection engine for LLM applications. 27 input detectors, 6 output scanners, cross-domain novel techniques (v0.4.0)."
+authors:
+  - family-names: "Munirathinam"
+    given-names: "Thamilvendhan"
+repository-code: "https://github.com/mthamil107/prompt-shield"
+url: "https://github.com/mthamil107/prompt-shield"
+license: Apache-2.0
+keywords:
+  - "llm"
+  - "security"
+  - "prompt-injection"
+  - "ai-safety"
+  - "firewall"
+  - "self-learning"
+preferred-citation:
+  type: generic
+  title: "Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection"
+  authors:
+    - family-names: "Munirathinam"
+      given-names: "Thamilvendhan"
+  year: 2026
+  doi: "10.5281/zenodo.19644135"
+  url: "https://doi.org/10.5281/zenodo.19644135"
+  version: "1.0.0"
+  publisher:
+    name: "Zenodo"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <img src="https://img.shields.io/badge/F1_score-96.0%25-success" alt="F1: 96.0%" />
   <img src="https://img.shields.io/badge/false_positives-0%25-success" alt="0% FP" />
   <img src="https://img.shields.io/badge/tests-800-blue" alt="800 tests" />
+  <a href="https://doi.org/10.5281/zenodo.19644135"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19644135.svg" alt="DOI" /></a>
 </p>
 
 <p align="center">
@@ -574,7 +575,16 @@ prompt-shield benchmark performance -n 100
 
 ## Research: Novel Cross-Domain Techniques (v0.4.0)
 
-> **Status: 1 of 7 shipped (d028 Smith-Waterman alignment landed in v0.4.0 phase 4). 6 in development.** These techniques draw from fields outside LLM security. Each is either genuinely novel in application to prompt injection, or a new runtime implementation of a method explored only statically or in research. Prior art is credited per-technique below. We welcome peer review, feedback, and contributions.
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19644135.svg)](https://doi.org/10.5281/zenodo.19644135)
+
+**Paper:** [*Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection*](https://zenodo.org/records/19644135) (Zenodo, v1.0.0) — a peer-reviewable write-up of the seven techniques below, with prior-art analysis, mechanisms, and references.
+
+**Cite as:**
+> Munirathinam, T. (2026). *Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection* (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.19644135
+
+A BibTeX entry lives at [`CITATION.cff`](CITATION.cff) (auto-rendered by GitHub's *Cite this repository* button in the sidebar). A local PDF copy is at [`docs/papers/cross-domain-techniques.pdf`](docs/papers/cross-domain-techniques.pdf).
+
+> **Implementation status: 1 of 7 shipped (d028 Smith-Waterman alignment landed in v0.4.0 phase 4). 6 in development.** These techniques draw from fields outside LLM security. Each is either genuinely novel in application to prompt injection, or a new runtime implementation of a method explored only statically or in research. Prior art is credited per-technique below. We welcome peer review, feedback, and contributions.
 
 The core insight behind v0.4.0 is that prompt injection detection has converged on two approaches -- regex patterns and ML classifiers -- both of which break under adaptive adversaries (see [NAACL 2025](https://aclanthology.org/2025.findings-naacl.395/), [ICLR 2025](https://openreview.net/forum?id=7B9mTg7z25)). We looked to other disciplines for fundamentally different detection signals.
 

--- a/docs/papers/README.md
+++ b/docs/papers/README.md
@@ -1,0 +1,19 @@
+# Papers
+
+Local copies of research papers associated with prompt-shield.
+
+## Cross-Domain Techniques (v0.4.0)
+
+- **File:** `cross-domain-techniques.pdf` *(add by downloading from Zenodo)*
+- **DOI:** [10.5281/zenodo.19644135](https://doi.org/10.5281/zenodo.19644135)
+- **Zenodo record:** https://zenodo.org/records/19644135
+- **Source markdown:** [`../research-post-cross-domain-techniques.md`](../research-post-cross-domain-techniques.md)
+
+To populate the PDF:
+
+```bash
+curl -L -o docs/papers/cross-domain-techniques.pdf \
+  https://zenodo.org/records/19644135/files/cross-domain-techniques.pdf
+```
+
+(adjust the filename to match the actual asset name on Zenodo). The PDF is not auto-downloaded in CI; it is committed once per published version.

--- a/docs/research-post-cross-domain-techniques.md
+++ b/docs/research-post-cross-domain-techniques.md
@@ -1,8 +1,11 @@
 # Beyond Pattern Matching: 7 Cross-Domain Techniques for Prompt Injection Detection
 
-**Authors:** prompt-shield contributors  
-**Date:** April 2026  
+**Author:** Thamilvendhan Munirathinam
+**Date:** April 2026
+**DOI:** [10.5281/zenodo.19644135](https://doi.org/10.5281/zenodo.19644135) (Zenodo, v1.0.0)
 **Repository:** [github.com/mthamil107/prompt-shield](https://github.com/mthamil107/prompt-shield)
+
+**Cite as:** Munirathinam, T. (2026). *Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection* (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.19644135
 
 ---
 


### PR DESCRIPTION
## Summary

The v0.4.0 cross-domain techniques write-up is now a permanently citable Zenodo record:

**DOI:** [10.5281/zenodo.19644135](https://doi.org/10.5281/zenodo.19644135)

This PR wires the DOI into the repo so the paper is discoverable from GitHub UI, the README badge row, and standard citation tooling.

## Changes

- **README.md**
  - DOI badge added to the badge row at the top (next to tests/detectors/FP badges).
  - Zenodo DOI badge + full citation block at the top of the existing "Research: Novel Cross-Domain Techniques" section, with "Cite as" line and pointers to `CITATION.cff` and `docs/papers/`.
- **`CITATION.cff`** (new) — standard Citation File Format so GitHub's *Cite this repository* sidebar button renders the Zenodo paper as the preferred citation, with the software repo as software fallback.
- **`docs/papers/README.md`** (new) — placeholder documenting where the PDF goes. The PDF itself is not in this commit; downloader stub is:
  ```
  curl -L -o docs/papers/cross-domain-techniques.pdf \
       https://zenodo.org/records/19644135/files/<asset>
  ```
- **`docs/research-post-cross-domain-techniques.md`** — front matter now carries DOI and citation, consistent with README.

## Cite as

> Munirathinam, T. (2026). *Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection* (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.19644135

## Test plan

- [x] DOI badge renders (Zenodo shield URL uses the standard pattern)
- [x] `CITATION.cff` validates (cff-version 1.2.0, preferred-citation.type = generic)
- [ ] GitHub sidebar *Cite this repository* button shows the Zenodo DOI after merge (verify post-merge)
- [ ] PDF dropped into `docs/papers/cross-domain-techniques.pdf` in a follow-up commit
- [ ] When arXiv endorsement comes through, add the arXiv ID as a Zenodo related-identifier and link it here