### PR TITLE
Phase 2: Adversarial fatigue tracker (v0.4.0, 2 of 7 techniques)

### DIFF
--- a/docs/papers/evaluation/fatigue_probing_campaign.md
+++ b/docs/papers/evaluation/fatigue_probing_campaign.md
@@ -1,0 +1,70 @@
+# Adversarial Fatigue — Probing-Campaign Evaluation
+
+**Technique:** `prompt_shield.fatigue.FatigueTracker` (v0.4.0 phase 2)
+**Status:** Shipped (opt-in via `fatigue.enabled: true`).
+**Why this doc exists:** Unlike d028, the fatigue tracker is a *temporal* signal — it only surfaces across repeated scans from the same source. Running it on static public datasets (deepset, NotInject, LLMail-Inject, AgentHarm, AgentDojo) shows no movement because every sample is evaluated in isolation. The meaningful empirical test is a simulated probing campaign.
+
+## How it works in one sentence
+
+For every (source, detector) pair the tracker keeps an EWMA of the near-miss indicator; once the EWMA exceeds `trigger_ratio` and enough samples have been seen, the detector threshold for that specific source is lowered by `harden_delta` until `cooldown_seconds` of quiet traffic pass.
+
+## The empirical claim
+
+The claim: **a repeating probing campaign that plants confidences consistently in the near-miss band will eventually be caught even without the attacker crossing the original threshold.**
+
+This claim is validated end-to-end in [`tests/fatigue/test_engine_integration.py`](../../../tests/fatigue/test_engine_integration.py). The relevant test `test_hardening_catches_next_near_miss` reproduces the exact scenario:
+
+1. Build an engine with `fatigue.enabled: true`, base detector threshold `0.7`.
+2. Submit 10 sequential scans from source `"attacker"` with a detector confidence of `0.65` — every one is a near-miss, but strictly below threshold, so without fatigue all 10 would pass.
+3. Submit an 11th scan from the same source with a confidence of `0.63` — *lower* than any previous scan, well below the original `0.7` threshold.
+4. Assert that the 11th scan is **blocked**.
+
+After the 10 priming scans, the EWMA crosses `trigger_ratio=0.3`, the pair hardens, and the effective threshold drops to `0.7 - 0.10 = 0.60`. A confidence of `0.63` now clears the effective threshold and is flagged.
+
+A parallel test (`test_benign_source_unaffected_by_attacker_campaign`) confirms that a different source concurrently scanning `0.63` stays pass-rated — the hardening is isolated to the probing source, not global.
+
+## Why public datasets do not exhibit movement
+
+The five public datasets used for d028 are static:
+
+- `deepset/prompt-injections` — 116 samples, each evaluated independently.
+- `leolee99/NotInject` — 339 benign inputs, no shared "source".
+- `microsoft/llmail-inject-challenge` — 1 000 attack attempts, each a distinct row.
+- `ai-safety-institute/AgentHarm` — 352 one-shot prompts.
+- `ethz-spylab/agentdojo` — 132 task definitions, one per test.
+
+Running the existing harness with `fatigue.enabled: true` produces an F1 delta indistinguishable from zero for every dataset, because:
+- All samples scan with no `source` key → they share the `"_global_"` bucket.
+- Most attack samples score well above the threshold so are not near-misses → EWMA stays at ~0.
+- The few near-miss-scoring samples are too sparse to cross `trigger_ratio` within a single benchmark run.
+
+This is not a negative result about fatigue — it is confirmation that fatigue is **orthogonal** to content-signal evaluation. Attempting to improve these F1 numbers with fatigue would be a category error.
+
+## What *would* validate fatigue on a public benchmark
+
+A dataset whose rows are **time-ordered probing sequences grouped by session** — not individual content samples. We are not aware of one that currently exists. Candidate sources:
+
+- Generate synthetically: take 1 000 distinct paraphrases of a single attack and submit them with a shared `source="campaign_1"`. Measure how many get blocked after fatigue trips.
+- Record-and-replay: instrument a live prompt-shield deployment, pseudonymise IPs, release as a public dataset. Future work.
+
+The synthetic-campaign generator is low-effort and can be added in a follow-up PR — that produces a publishable number for the paper's Evaluation section.
+
+## Reproduction
+
+```bash
+# Unit + integration tests
+python -m pytest tests/fatigue/ -v
+
+# The probing-campaign assertion specifically
+python -m pytest tests/fatigue/test_engine_integration.py::TestFatigueEnabled::test_hardening_catches_next_near_miss -v
+```
+
+Both go green in < 1 s. 29 fatigue-specific tests in total, 0 failures.
+
+## Paper write-up framing
+
+When this result appears in the paper's Evaluation section, recommended framing:
+
+> Fatigue-detection validation is qualitatively different from the content-signal benchmarks: the technique requires temporally-ordered scans grouped by source, which the public prompt-injection datasets do not provide. We validate the mechanism end-to-end on a synthetic probing campaign (Appendix X, reproducible via `tests/fatigue/test_engine_integration.py`) and defer a public-dataset evaluation to future work alongside a proposed session-grouped benchmark format.
+
+Do not claim a public-dataset F1 delta for fatigue. Owning the scope honestly is the defensible move.

--- a/src/prompt_shield/config/default.yaml
+++ b/src/prompt_shield/config/default.yaml
@@ -26,6 +26,20 @@ prompt_shield:
   scoring:
     ensemble_bonus: 0.05
 
+  # Adversarial fatigue tracking — detect probing campaigns across scans.
+  # Opt-in: when disabled (the default) there is zero runtime cost.
+  # See docs/research-post-cross-domain-techniques.md Section 2 and
+  # src/prompt_shield/fatigue/tracker.py for the mechanism.
+  fatigue:
+    enabled: false
+    near_miss_delta: 0.15          # range below threshold that counts as near-miss
+    ewma_alpha: 0.3                # smoothing factor (higher = more reactive)
+    trigger_ratio: 0.4             # EWMA level at which hardening activates
+    harden_delta: 0.10             # threshold lowering while hardened
+    cooldown_seconds: 60           # quiet interval before restoring base threshold
+    min_samples_before_trigger: 8  # prevents trigger on tiny sample sizes
+    source_key: "source"           # which context key identifies the caller
+
   data_dir: null
 
   vault:

--- a/src/prompt_shield/engine.py
+++ b/src/prompt_shield/engine.py
@@ -36,6 +36,7 @@ from prompt_shield.utils import sha256_hash
 
 if TYPE_CHECKING:
     from prompt_shield.detectors.base import BaseDetector
+    from prompt_shield.fatigue.tracker import FatigueTracker
     from prompt_shield.feedback.auto_tuner import AutoTuner
     from prompt_shield.feedback.feedback_store import FeedbackStore
     from prompt_shield.vault.attack_vault import AttackVault
@@ -117,6 +118,17 @@ class PromptShieldEngine:
             from prompt_shield.alerting.webhook import WebhookAlerter
 
             self._alerter = WebhookAlerter(alerting_cfg)
+
+        # Initialize adversarial fatigue tracker (opt-in, default-off).
+        # When disabled, observe() and get_effective_threshold() are no-ops
+        # so the hot scan path incurs two cheap `is None` checks at most.
+        self._fatigue: FatigueTracker | None = None
+        fatigue_cfg = self._ps_config.get("fatigue", {})
+        if fatigue_cfg.get("enabled", False):
+            from prompt_shield.fatigue import FatigueTracker as _FatigueTracker
+            from prompt_shield.fatigue.tracker import FatigueConfig as _FatigueConfig
+
+            self._fatigue = _FatigueTracker(_FatigueConfig.from_dict(fatigue_cfg))
 
         # Compile allowlist/blocklist patterns
         self._allowlist_patterns = self._compile_patterns(
@@ -229,27 +241,46 @@ class PromptShieldEngine:
                     risk_score=1.0,
                 )
 
-        # Build list of detectors to run with their configs/thresholds
-        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float]] = []
+        # Resolve fatigue source identifier once per scan (when enabled).
+        fatigue_source = (
+            str(ctx.get(self._fatigue.source_key, "_global_"))
+            if self._fatigue is not None
+            else None
+        )
+
+        # Build list of detectors to run with their configs/thresholds.
+        # The tuple now carries the *base* threshold too, so the runner can
+        # record that base value to the fatigue tracker (which classifies
+        # near-misses against the un-hardened threshold).
+        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float, float]] = []
         for detector in self._registry.list_all():
             det_cfg = get_detector_config(self._config, detector.detector_id)
             if not det_cfg.get("enabled", True):
                 continue
 
-            threshold = det_cfg.get("threshold", self._ps_config.get("threshold", 0.7))
+            base_threshold = det_cfg.get("threshold", self._ps_config.get("threshold", 0.7))
+            threshold = base_threshold
             if self._auto_tuner:
                 threshold = self._auto_tuner.get_effective_threshold(
                     detector.detector_id, threshold
                 )
-            detectors_to_run.append((detector, det_cfg, threshold))
+            if self._fatigue is not None and fatigue_source is not None:
+                threshold = self._fatigue.get_effective_threshold(
+                    fatigue_source, detector.detector_id, threshold
+                )
+            detectors_to_run.append((detector, det_cfg, threshold, base_threshold))
 
         total_run = len(detectors_to_run)
         detections: list[DetectionResult] = []
 
         if self._parallel and total_run > 1:
-            detections = self._run_detectors_parallel(detectors_to_run, input_text, ctx)
+            detections = self._run_detectors_parallel(
+                detectors_to_run, input_text, ctx, fatigue_source=fatigue_source
+            )
         else:
-            detections = self._run_detectors_sequential(detectors_to_run, input_text, ctx)
+            detections = self._run_detectors_sequential(
+                detectors_to_run, input_text, ctx, fatigue_source=fatigue_source
+            )
 
         # Aggregate risk score with ensemble bonus
         if detections:
@@ -457,13 +488,15 @@ class PromptShieldEngine:
 
     def _run_detectors_sequential(
         self,
-        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float]],
+        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float, float]],
         input_text: str,
         ctx: dict[str, object],
+        *,
+        fatigue_source: str | None = None,
     ) -> list[DetectionResult]:
         """Run detectors sequentially and collect results."""
         detections: list[DetectionResult] = []
-        for detector, det_cfg, threshold in detectors_to_run:
+        for detector, det_cfg, threshold, base_threshold in detectors_to_run:
             try:
                 result = detector.detect(input_text, context=ctx)
 
@@ -471,6 +504,14 @@ class PromptShieldEngine:
                 if cfg_severity:
                     with contextlib.suppress(ValueError):
                         result.severity = Severity(cfg_severity)
+
+                if self._fatigue is not None and fatigue_source is not None:
+                    self._fatigue.observe(
+                        fatigue_source,
+                        detector.detector_id,
+                        result.confidence,
+                        base_threshold,
+                    )
 
                 if result.detected and result.confidence >= threshold:
                     detections.append(result)
@@ -480,15 +521,20 @@ class PromptShieldEngine:
 
     def _run_detectors_parallel(
         self,
-        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float]],
+        detectors_to_run: list[tuple[BaseDetector, dict[str, Any], float, float]],
         input_text: str,
         ctx: dict[str, object],
+        *,
+        fatigue_source: str | None = None,
     ) -> list[DetectionResult]:
         """Run detectors in parallel using ThreadPoolExecutor."""
         detections: list[DetectionResult] = []
 
         def _run_one(
-            detector: BaseDetector, det_cfg: dict[str, Any], threshold: float
+            detector: BaseDetector,
+            det_cfg: dict[str, Any],
+            threshold: float,
+            base_threshold: float,
         ) -> DetectionResult | None:
             result = detector.detect(input_text, context=ctx)
 
@@ -497,14 +543,22 @@ class PromptShieldEngine:
                 with contextlib.suppress(ValueError):
                     result.severity = Severity(cfg_severity)
 
+            if self._fatigue is not None and fatigue_source is not None:
+                self._fatigue.observe(
+                    fatigue_source,
+                    detector.detector_id,
+                    result.confidence,
+                    base_threshold,
+                )
+
             if result.detected and result.confidence >= threshold:
                 return result
             return None
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = {
-                executor.submit(_run_one, detector, det_cfg, threshold): detector
-                for detector, det_cfg, threshold in detectors_to_run
+                executor.submit(_run_one, detector, det_cfg, threshold, base_threshold): detector
+                for detector, det_cfg, threshold, base_threshold in detectors_to_run
             }
             for future in as_completed(futures):
                 detector = futures[future]

--- a/src/prompt_shield/fatigue/__init__.py
+++ b/src/prompt_shield/fatigue/__init__.py
@@ -1,0 +1,10 @@
+"""Adversarial fatigue tracking — detect probing campaigns across scans.
+
+See :class:`FatigueTracker` for the public API. The tracker is opt-in via
+the ``fatigue.enabled`` config key; when disabled the module imposes zero
+runtime cost on the scan path.
+"""
+
+from prompt_shield.fatigue.tracker import FatigueTracker
+
+__all__ = ["FatigueTracker"]

--- a/src/prompt_shield/fatigue/tracker.py
+++ b/src/prompt_shield/fatigue/tracker.py
@@ -1,0 +1,241 @@
+"""Adversarial fatigue tracker — detects probing campaigns via EWMA near-miss rate.
+
+Cross-domain origin: materials-science S-N (stress-number-of-cycles) fatigue
+curves predict structural failure under repeated stress below the
+single-cycle threshold. We model adversarial prompt-injection the same way:
+each individual scan may land just below the detection threshold, but a
+sustained pattern of such near-misses from the same source is itself a
+detection signal.
+
+Mechanism:
+
+1. For every scan, observe the (source, detector_id, confidence,
+   base_threshold) tuple.
+2. Classify each observation as a *near-miss* if
+   ``base_threshold - near_miss_delta <= confidence < base_threshold``.
+3. Update an exponentially weighted moving average (EWMA) of the near-miss
+   indicator per (source, detector) pair.
+4. When the EWMA exceeds ``trigger_ratio``, mark the pair as *hardened*.
+   While hardened, ``get_effective_threshold`` returns
+   ``base_threshold - harden_delta``, making it harder for near-boundary
+   probes to evade detection.
+5. When the pair has had no near-miss for ``cooldown_seconds``, restore the
+   base threshold.
+
+Default-off via ``fatigue.enabled``. When off the engine skips all
+observe/get_effective_threshold calls (zero-overhead).
+
+Thread-safety: the tracker uses a single ``threading.Lock`` around state
+mutation, so the same instance is safe under the engine's parallel
+detector execution.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class _Entry:
+    """Per-(source, detector_id) fatigue state."""
+
+    ewma_near_miss: float = 0.0
+    last_near_miss_ts: float = 0.0  # monotonic-clock timestamp
+    hardened: bool = False
+    hardened_at_ts: float = 0.0  # monotonic-clock timestamp
+    samples_seen: int = 0
+
+
+@dataclass
+class FatigueConfig:
+    """Configuration values (parsed from the ``fatigue:`` config block)."""
+
+    enabled: bool = False
+    near_miss_delta: float = 0.15
+    ewma_alpha: float = 0.3
+    trigger_ratio: float = 0.4
+    harden_delta: float = 0.10
+    cooldown_seconds: float = 60.0
+    min_samples_before_trigger: int = 8
+    source_key: str = "source"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object] | None) -> FatigueConfig:
+        if not data:
+            return cls()
+
+        def _f(key: str, default: float) -> float:
+            v = data.get(key, default)
+            return float(v) if isinstance(v, (int, float, str)) else default
+
+        def _i(key: str, default: int) -> int:
+            v = data.get(key, default)
+            return int(v) if isinstance(v, (int, float, str)) else default
+
+        def _b(key: str, default: bool) -> bool:
+            v = data.get(key, default)
+            return bool(v) if isinstance(v, (bool, int)) else default
+
+        def _s(key: str, default: str) -> str:
+            v = data.get(key, default)
+            return str(v) if isinstance(v, str) else default
+
+        return cls(
+            enabled=_b("enabled", False),
+            near_miss_delta=_f("near_miss_delta", 0.15),
+            ewma_alpha=_f("ewma_alpha", 0.3),
+            trigger_ratio=_f("trigger_ratio", 0.4),
+            harden_delta=_f("harden_delta", 0.10),
+            cooldown_seconds=_f("cooldown_seconds", 60.0),
+            min_samples_before_trigger=_i("min_samples_before_trigger", 8),
+            source_key=_s("source_key", "source"),
+        )
+
+
+class FatigueTracker:
+    """Per-(source, detector) EWMA near-miss tracker with threshold hardening.
+
+    Cheap in both RAM and CPU: one small object per active (source, detector)
+    pair, a dict lookup + constant-time math per scan observation. No disk,
+    no network. State resets on process restart (intended — fatigue is a
+    short-window signal, not a durable profile).
+    """
+
+    def __init__(self, config: FatigueConfig | None = None) -> None:
+        self._config = config or FatigueConfig()
+        self._entries: dict[tuple[str, str], _Entry] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------ API
+
+    @property
+    def config(self) -> FatigueConfig:
+        return self._config
+
+    @property
+    def source_key(self) -> str:
+        return self._config.source_key
+
+    def observe(
+        self,
+        source: str,
+        detector_id: str,
+        confidence: float,
+        base_threshold: float,
+        *,
+        now: float | None = None,
+    ) -> None:
+        """Record a single scan observation.
+
+        Parameters
+        ----------
+        source
+            Caller-supplied identifier isolating one attacker/session/IP from
+            another. Use ``"_global_"`` when the caller does not provide one.
+        detector_id
+            The detector whose confidence this observation describes.
+        confidence
+            Detector confidence in [0.0, 1.0].
+        base_threshold
+            The detector's threshold *before* fatigue hardening. Used to
+            classify the observation as a near-miss or not.
+        now
+            Optional monotonic timestamp override — for tests.
+        """
+        if not self._config.enabled:
+            return
+
+        ts = now if now is not None else time.monotonic()
+        key = (source, detector_id)
+
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                entry = _Entry()
+                self._entries[key] = entry
+
+            is_near_miss = self._is_near_miss(confidence, base_threshold)
+            indicator = 1.0 if is_near_miss else 0.0
+            alpha = self._config.ewma_alpha
+            entry.ewma_near_miss = alpha * indicator + (1 - alpha) * entry.ewma_near_miss
+            entry.samples_seen += 1
+            if is_near_miss:
+                entry.last_near_miss_ts = ts
+
+            # Cooldown: if hardened and quiet for long enough, restore.
+            # Also reset EWMA so we don't immediately re-trigger hardening on
+            # the same observation — the semantic is "attacker has gone away,
+            # forget what happened before; if they come back the EWMA
+            # rebuilds from zero".
+            if entry.hardened and not is_near_miss:
+                quiet_for = ts - entry.last_near_miss_ts
+                if quiet_for >= self._config.cooldown_seconds:
+                    entry.hardened = False
+                    entry.ewma_near_miss = 0.0
+                    entry.samples_seen = 0
+
+            # Trigger hardening if the near-miss EWMA exceeds threshold
+            # AND we have enough samples for the signal to be meaningful.
+            if (
+                not entry.hardened
+                and entry.samples_seen >= self._config.min_samples_before_trigger
+                and entry.ewma_near_miss > self._config.trigger_ratio
+            ):
+                entry.hardened = True
+                entry.hardened_at_ts = ts
+
+    def get_effective_threshold(
+        self,
+        source: str,
+        detector_id: str,
+        base_threshold: float,
+    ) -> float:
+        """Return the threshold to use for this scan.
+
+        Identical to ``base_threshold`` unless the (source, detector) pair is
+        currently hardened, in which case the threshold is lowered by
+        ``harden_delta`` (clamped to [0.0, 1.0]).
+        """
+        if not self._config.enabled:
+            return base_threshold
+        key = (source, detector_id)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None or not entry.hardened:
+                return base_threshold
+            return max(0.0, min(1.0, base_threshold - self._config.harden_delta))
+
+    def is_hardened(self, source: str, detector_id: str) -> bool:
+        """Inspect current hardening state (observability + tests)."""
+        if not self._config.enabled:
+            return False
+        with self._lock:
+            entry = self._entries.get((source, detector_id))
+            return bool(entry and entry.hardened)
+
+    def snapshot(self) -> dict[tuple[str, str], dict[str, float | bool | int]]:
+        """Return a deep snapshot of internal state — diagnostic use only."""
+        with self._lock:
+            return {
+                key: {
+                    "ewma_near_miss": e.ewma_near_miss,
+                    "hardened": e.hardened,
+                    "samples_seen": e.samples_seen,
+                    "last_near_miss_ts": e.last_near_miss_ts,
+                    "hardened_at_ts": e.hardened_at_ts,
+                }
+                for key, e in self._entries.items()
+            }
+
+    def reset(self) -> None:
+        """Drop all state (used by tests; not normally called at runtime)."""
+        with self._lock:
+            self._entries.clear()
+
+    # ----------------------------------------------------------------- help
+
+    def _is_near_miss(self, confidence: float, base_threshold: float) -> bool:
+        lower = base_threshold - self._config.near_miss_delta
+        return lower <= confidence < base_threshold

--- a/tests/fatigue/test_engine_integration.py
+++ b/tests/fatigue/test_engine_integration.py
@@ -1,0 +1,168 @@
+"""End-to-end tests: engine wires fatigue tracker into the scan path.
+
+Uses a dummy detector with a controllable confidence so we can construct
+a probing campaign that lands reliably in the near-miss range, rather
+than depending on the brittle behaviour of real text-input patterns.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from prompt_shield.detectors.base import BaseDetector
+from prompt_shield.engine import PromptShieldEngine
+from prompt_shield.models import DetectionResult, Severity
+
+
+class _FixedConfidenceDetector(BaseDetector):
+    """Detector whose confidence can be set per-scan via context."""
+
+    detector_id: str = "dummy_fixed"
+    name: str = "Dummy fixed-confidence detector"
+    description: str = "Returns a preset confidence for every scan; used in tests."
+    severity: Severity = Severity.HIGH
+    tags: ClassVar[list[str]] = ["test"]
+    version: str = "0.0.1"
+    author: str = "test"
+
+    def detect(self, input_text: str, context: dict[str, object] | None = None) -> DetectionResult:
+        ctx = context or {}
+        confidence = float(ctx.get("fixed_confidence", 0.0))  # type: ignore[arg-type]
+        return DetectionResult(
+            detector_id=self.detector_id,
+            detected=confidence > 0.0,
+            confidence=confidence,
+            severity=self.severity,
+            explanation=f"fixed-confidence detector returned {confidence}",
+        )
+
+
+def _build_engine(
+    *,
+    fatigue_enabled: bool = True,
+    min_samples: int = 5,
+    trigger_ratio: float = 0.3,
+    threshold: float = 0.7,
+) -> PromptShieldEngine:
+    engine = PromptShieldEngine(
+        config_dict={
+            "prompt_shield": {
+                "mode": "block",
+                "threshold": threshold,
+                "parallel": False,
+                "vault": {"enabled": False},
+                "feedback": {"enabled": False},
+                "canary": {"enabled": False},
+                "history": {"enabled": False},
+                "detectors": {
+                    "d022_semantic_classifier": {"enabled": False},
+                },
+                "fatigue": {
+                    "enabled": fatigue_enabled,
+                    "min_samples_before_trigger": min_samples,
+                    "trigger_ratio": trigger_ratio,
+                    "near_miss_delta": 0.15,
+                    "ewma_alpha": 0.5,  # more reactive for tests
+                    "harden_delta": 0.10,
+                    "cooldown_seconds": 60,
+                },
+            }
+        }
+    )
+    # Remove every real detector so only the dummy fires — keeps the test
+    # signal clean regardless of future detector additions.
+    for det in list(engine._registry.list_all()):
+        engine._registry.unregister(det.detector_id)
+    engine._registry.register(_FixedConfidenceDetector())
+    return engine
+
+
+class TestFatigueDisabled:
+    def test_engine_scan_path_unchanged(self) -> None:
+        """With fatigue off, the tracker attribute is None and scans behave identically."""
+        engine = _build_engine(fatigue_enabled=False)
+        assert engine._fatigue is None
+        report = engine.scan("hello", context={"fixed_confidence": 0.65})
+        # below threshold 0.7 → pass
+        assert report.action.value == "pass"
+        assert len(report.detections) == 0
+
+
+class TestFatigueEnabled:
+    def test_probing_campaign_triggers_hardening(self) -> None:
+        engine = _build_engine(min_samples=5)
+        assert engine._fatigue is not None
+
+        # 10 near-miss scans (conf 0.65, threshold 0.7) from the same source.
+        for _ in range(10):
+            engine.scan("probe", context={"source": "attacker", "fixed_confidence": 0.65})
+
+        # After enough samples the (source, detector) pair must be hardened.
+        assert engine._fatigue.is_hardened("attacker", "dummy_fixed") is True
+
+    def test_hardening_catches_next_near_miss(self) -> None:
+        """Once hardened, a confidence that previously passed should now block."""
+        engine = _build_engine(min_samples=5)
+
+        # Build up fatigue
+        for _ in range(10):
+            engine.scan("probe", context={"source": "attacker", "fixed_confidence": 0.65})
+
+        # Before fatigue, conf 0.63 was below threshold 0.7 → would pass.
+        # After fatigue, threshold hardens to 0.6 → 0.63 now blocks.
+        report = engine.scan("probe", context={"source": "attacker", "fixed_confidence": 0.63})
+        assert report.action.value == "block"
+        assert len(report.detections) == 1
+
+    def test_benign_source_unaffected_by_attacker_campaign(self) -> None:
+        """Per-source isolation must hold at the engine level."""
+        engine = _build_engine(min_samples=5)
+
+        for _ in range(10):
+            engine.scan("probe", context={"source": "attacker", "fixed_confidence": 0.65})
+
+        # A DIFFERENT source scanning conf 0.63 should still pass — their
+        # threshold is not hardened.
+        report = engine.scan("ok", context={"source": "benign_user", "fixed_confidence": 0.63})
+        assert report.action.value == "pass"
+        assert engine._fatigue is not None
+        assert engine._fatigue.is_hardened("benign_user", "dummy_fixed") is False
+
+    def test_global_bucket_used_when_no_source_provided(self) -> None:
+        """When the caller omits a ``source`` key the tracker uses ``_global_``."""
+        engine = _build_engine(min_samples=5)
+
+        for _ in range(10):
+            engine.scan("probe", context={"fixed_confidence": 0.65})
+
+        assert engine._fatigue is not None
+        assert engine._fatigue.is_hardened("_global_", "dummy_fixed") is True
+
+    def test_benign_traffic_never_hardens(self) -> None:
+        """Traffic well below the near-miss band must not trip fatigue."""
+        engine = _build_engine(min_samples=5)
+
+        for _ in range(50):
+            engine.scan("clean", context={"source": "user", "fixed_confidence": 0.05})
+
+        assert engine._fatigue is not None
+        assert engine._fatigue.is_hardened("user", "dummy_fixed") is False
+
+    def test_parallel_runner_also_observes(self) -> None:
+        """Parallel execution path must call observe() too."""
+        engine = _build_engine(min_samples=5)
+        engine._parallel = True  # force the parallel runner
+
+        # Register a second dummy so total_run > 1 triggers parallel code path.
+        class _Second(_FixedConfidenceDetector):
+            detector_id: str = "dummy_second"
+
+        engine._registry.register(_Second())
+
+        for _ in range(10):
+            engine.scan("probe", context={"source": "attacker", "fixed_confidence": 0.65})
+
+        assert engine._fatigue is not None
+        # Both detectors should have observed and hardened
+        assert engine._fatigue.is_hardened("attacker", "dummy_fixed") is True
+        assert engine._fatigue.is_hardened("attacker", "dummy_second") is True

--- a/tests/fatigue/test_tracker.py
+++ b/tests/fatigue/test_tracker.py
@@ -1,0 +1,200 @@
+"""Unit tests for the adversarial fatigue tracker."""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_shield.fatigue.tracker import FatigueConfig, FatigueTracker
+
+
+def _enabled_config(**overrides: object) -> FatigueConfig:
+    """Build an enabled FatigueConfig with tighter defaults for fast tests."""
+    base = dict(
+        enabled=True,
+        near_miss_delta=0.15,
+        ewma_alpha=0.3,
+        trigger_ratio=0.4,
+        harden_delta=0.10,
+        cooldown_seconds=60.0,
+        min_samples_before_trigger=8,
+        source_key="source",
+    )
+    base.update(overrides)
+    return FatigueConfig(**base)  # type: ignore[arg-type]
+
+
+class TestFatigueConfig:
+    def test_default_disabled(self) -> None:
+        cfg = FatigueConfig()
+        assert cfg.enabled is False
+        assert cfg.ewma_alpha == 0.3
+        assert cfg.trigger_ratio == 0.4
+        assert cfg.harden_delta == 0.10
+        assert cfg.source_key == "source"
+
+    def test_from_dict_none(self) -> None:
+        assert FatigueConfig.from_dict(None).enabled is False
+        assert FatigueConfig.from_dict({}).enabled is False
+
+    def test_from_dict_overrides(self) -> None:
+        cfg = FatigueConfig.from_dict(
+            {"enabled": True, "trigger_ratio": 0.25, "cooldown_seconds": 10}
+        )
+        assert cfg.enabled is True
+        assert cfg.trigger_ratio == 0.25
+        assert cfg.cooldown_seconds == 10.0
+
+
+class TestDisabledTracker:
+    """With enabled=False the tracker must be a total no-op."""
+
+    def test_observe_is_noop(self) -> None:
+        t = FatigueTracker()  # default: enabled=False
+        t.observe("src", "d001", confidence=0.65, base_threshold=0.7)
+        assert t.snapshot() == {}
+
+    def test_get_effective_threshold_returns_base(self) -> None:
+        t = FatigueTracker()
+        assert t.get_effective_threshold("src", "d001", 0.7) == 0.7
+
+    def test_is_hardened_false(self) -> None:
+        t = FatigueTracker()
+        assert t.is_hardened("src", "d001") is False
+
+
+class TestNearMissClassification:
+    def test_near_miss_range(self) -> None:
+        t = FatigueTracker(_enabled_config())
+        # threshold=0.7, delta=0.15 -> near-miss range [0.55, 0.70)
+        assert t._is_near_miss(0.55, 0.7) is True
+        assert t._is_near_miss(0.60, 0.7) is True
+        assert t._is_near_miss(0.69, 0.7) is True
+
+    def test_above_threshold_not_near_miss(self) -> None:
+        t = FatigueTracker(_enabled_config())
+        # >= threshold is a caught attack, not a near-miss
+        assert t._is_near_miss(0.70, 0.7) is False
+        assert t._is_near_miss(0.85, 0.7) is False
+
+    def test_below_window_not_near_miss(self) -> None:
+        t = FatigueTracker(_enabled_config())
+        assert t._is_near_miss(0.54, 0.7) is False
+        assert t._is_near_miss(0.0, 0.7) is False
+
+
+class TestEwmaAccumulation:
+    def test_single_observation_updates_ewma(self) -> None:
+        t = FatigueTracker(_enabled_config())
+        t.observe("src", "d001", confidence=0.65, base_threshold=0.7, now=0)
+        snap = t.snapshot()[("src", "d001")]
+        # EWMA: alpha*1 + (1-alpha)*0 = 0.3
+        assert snap["ewma_near_miss"] == pytest.approx(0.3)
+        assert snap["samples_seen"] == 1
+
+    def test_benign_observation_decays_ewma(self) -> None:
+        t = FatigueTracker(_enabled_config())
+        t.observe("src", "d001", confidence=0.65, base_threshold=0.7, now=0)  # near-miss
+        t.observe("src", "d001", confidence=0.10, base_threshold=0.7, now=1)  # benign
+        snap = t.snapshot()[("src", "d001")]
+        # EWMA: 0.3 * 0 + 0.7 * 0.3 = 0.21
+        assert snap["ewma_near_miss"] == pytest.approx(0.21)
+        assert snap["samples_seen"] == 2
+
+
+class TestHardeningTrigger:
+    def test_sustained_probing_hardens(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is True
+
+    def test_effective_threshold_lowers_when_hardened(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        eff = t.get_effective_threshold("attacker", "d001", 0.7)
+        assert eff == pytest.approx(0.6)  # 0.7 - harden_delta 0.10
+
+    def test_not_hardened_before_min_samples(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=20))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is False
+
+    def test_benign_traffic_does_not_harden(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(50):
+            t.observe("user", "d001", confidence=0.05, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("user", "d001") is False
+
+
+class TestPerSourceIsolation:
+    def test_one_source_probing_does_not_harden_another(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+            t.observe("benign_user", "d001", confidence=0.05, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is True
+        assert t.is_hardened("benign_user", "d001") is False
+        assert t.get_effective_threshold("benign_user", "d001", 0.7) == 0.7
+
+    def test_per_detector_isolation(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is True
+        assert t.is_hardened("attacker", "d002") is False
+
+
+class TestCooldownRestore:
+    def test_cooldown_restores_threshold(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5, cooldown_seconds=60))
+        # probing campaign
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is True
+
+        # quiet traffic (benign) for > cooldown_seconds should restore
+        # One benign observation at t=100 puts us 100-9=91s past the last near-miss
+        t.observe("attacker", "d001", confidence=0.05, base_threshold=0.7, now=100.0)
+        assert t.is_hardened("attacker", "d001") is False
+
+    def test_cooldown_not_triggered_by_continuing_probes(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5, cooldown_seconds=60))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        # continued probing — even at t=1000 should stay hardened because the
+        # last_near_miss_ts keeps advancing
+        for i in range(10, 1000):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.is_hardened("attacker", "d001") is True
+
+    def test_cooldown_not_restored_before_deadline(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5, cooldown_seconds=60))
+        for i in range(10):
+            t.observe("attacker", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+
+        # benign scan 30s later — still within cooldown window
+        t.observe("attacker", "d001", confidence=0.05, base_threshold=0.7, now=39.0)
+        assert t.is_hardened("attacker", "d001") is True
+
+
+class TestEffectiveThresholdClamping:
+    def test_clamped_to_zero(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5, harden_delta=0.9))
+        for i in range(10):
+            t.observe("src", "d001", confidence=0.1, base_threshold=0.1, now=float(i))
+        # threshold 0.1, harden 0.9 → would be -0.8, clamped to 0.0
+        eff = t.get_effective_threshold("src", "d001", 0.1)
+        assert 0.0 <= eff <= 1.0
+
+
+class TestReset:
+    def test_reset_clears_state(self) -> None:
+        t = FatigueTracker(_enabled_config(min_samples_before_trigger=5))
+        for i in range(10):
+            t.observe("a", "d001", confidence=0.65, base_threshold=0.7, now=float(i))
+        assert t.snapshot()
+        t.reset()
+        assert t.snapshot() == {}
+        assert t.is_hardened("a", "d001") is False


### PR DESCRIPTION
## Summary

Ships the second of seven novel cross-domain techniques from the v0.4.0 plan: an **EWMA-based adversarial fatigue tracker** that detects probing campaigns and temporarily hardens detection thresholds for the offending source. Cross-domain origin: materials-science S-N fatigue curves. Opt-in, zero-impact by default.

This brings the arXiv-bar count to **2 of 7 techniques shipped** (d028 already merged on main; fatigue now).

## What it does

For every `(source, detector)` pair, track a per-scan EWMA of the near-miss indicator (confidence in `[threshold - 0.15, threshold)`). Once the EWMA exceeds `trigger_ratio` and enough samples have been seen, lower the threshold for that specific source by `harden_delta` until `cooldown_seconds` of quiet traffic pass.

Net effect: a probing campaign that plants 10 scans at confidence 0.65 (below threshold 0.7) can get the 11th scan — even at a *lower* confidence of 0.63 — blocked, because the effective threshold has hardened to 0.60. A benign source running at the same time is unaffected.

## Files

**New:**
- `src/prompt_shield/fatigue/tracker.py` (~200 lines) — FatigueTracker + FatigueConfig
- `src/prompt_shield/fatigue/__init__.py` — public re-export
- `tests/fatigue/test_tracker.py` (22 tests) — unit
- `tests/fatigue/test_engine_integration.py` (7 tests) — end-to-end via a dummy fixed-confidence detector
- `docs/papers/evaluation/fatigue_probing_campaign.md` — honest evaluation framing

**Edited:**
- `src/prompt_shield/engine.py` — wired tracker into threshold resolution + detector runners; detector tuple gains a `base_threshold` slot so the tracker can classify against the un-hardened threshold
- `src/prompt_shield/config/default.yaml` — `fatigue` block with `enabled: false` default

## Zero-regression guarantee

With `fatigue.enabled: false` (the default) the engine does one `is None` check per scan. All prior behaviour is byte-identical.

| Gate | Before | After |
|---|---|---|
| pytest total | 800 | **829** (+29 fatigue) |
| ruff check | clean | clean |
| ruff format --check | clean | clean |
| mypy src/ | clean | clean |
| realistic benchmark, 12 categories | baseline | unchanged |
| benign FP count | 0 | 0 |
| overall detection rate | 82.5 % | 82.5 % |

## Empirical validation

Static public datasets (deepset, NotInject, LLMail-Inject, AgentHarm, AgentDojo) are **not session-grouped** — every row is an independent sample — so fatigue cannot move F1 on them by construction. This is documented honestly in [`docs/papers/evaluation/fatigue_probing_campaign.md`](docs/papers/evaluation/fatigue_probing_campaign.md).

The meaningful validation is the probing-campaign integration test (`test_hardening_catches_next_near_miss`): 10 priming scans at conf 0.65 → 11th scan at conf 0.63 is blocked. Reproducible via `python -m pytest tests/fatigue/`.

## Cooldown bug caught in unit tests

Original logic restored `hardened=False` after cooldown but left the EWMA above `trigger_ratio`, immediately re-hardening on the same `observe()` call. Fixed by also resetting `ewma_near_miss` and `samples_seen` when hardening clears — semantically, "attacker went away, start fresh".

## Test plan

- [x] 29 new fatigue tests pass
- [x] 800 existing tests still pass
- [x] ruff / format / mypy all clean
- [x] regression_check.py clean on all 12 categories
- [ ] CI across Python 3.10-3.13

## Next

**Phase 5 (LMSR prediction market)** is the last remaining technique before hitting Wagner's 3-techniques-benchmarked bar. It's the riskiest (touches core scoring + needs new SQLite migration for `scan_confidences` and `scan_labels`), so it's worth landing in its own PR with extra care.